### PR TITLE
[COOK-1285] add support for native bindings

### DIFF
--- a/providers/site.rb
+++ b/providers/site.rb
@@ -28,9 +28,13 @@ action :add do
     cmd = "#{appcmd} add site /name:\"#{@new_resource.site_name}\""
     cmd << " /id:#{@new_resource.site_id}" if @new_resource.site_id
     cmd << " /physicalPath:\"#{win_friendly_path(@new_resource.path)}\"" if @new_resource.path
-    cmd << " /bindings:#{@new_resource.protocol}/*"
-    cmd << ":#{@new_resource.port}:" if @new_resource.port
-    cmd << "#{@new_resource.host_header}" if @new_resource.host_header
+    if @new_resource.bindings
+		cmd << " /bindings:#{@new_resource.bindings}"
+	else
+		cmd << " /bindings:#{@new_resource.protocol}/*"
+		cmd << ":#{@new_resource.port}:" if @new_resource.port
+		cmd << "#{@new_resource.host_header}" if @new_resource.host_header
+	end
     shell_out!(cmd, {:returns => [0,42]})
     @new_resource.updated_by_last_action(true)
     Chef::Log.info("#{@new_resource} added new site '#{@new_resource.site_name}'")

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -26,5 +26,6 @@ attribute :port, :kind_of => Integer
 attribute :path, :kind_of => String
 attribute :protocol, :kind_of => Symbol, :default => :http, :equal_to => [:http, :https]
 attribute :host_header, :kind_of => String, :default => nil
+attribute :bindings, :kind_of => String, :default => nil
 
 attr_accessor :exists, :running


### PR DESCRIPTION
Hi,

The current solution for the bindings doesn't allow for multiple host_header, port or protocol.
I've created a bindings attributes that has to contains specific iis bindings syntax to allow advanced configuration.

This is not a mandatory attribute, you can still use host_header, port and protocol attributes.

http://tickets.opscode.com/browse/COOK-1285
