### PR TITLE
[COOK-2526] Register ASP.NET after IIS

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,22 @@ include_recipe "webpi"
 webpi_product node['iis']['components'] do
   accept_eula node['iis']['accept_eula']
   action :install
+  notifies :run, "execute[Register ASP.NET v4]", :immediately
+  notifies :run, "execute[Register ASP.NET v4 (x64)]", :immediately
+end
+
+aspnet_regiis = "#{ENV['WinDir']}\\Microsoft.NET\\Framework\\v4.0.30319\\aspnet_regiis.exe"
+execute 'Register ASP.NET v4' do
+  command "#{aspnet_regiis} -i"
+  only_if { File.exists?(aspnet_regiis) }
+  action :nothing
+end
+
+aspnet_regiis64 = "#{ENV['WinDir']}\\Microsoft.NET\\Framework64\\v4.0.30319\\aspnet_regiis.exe"
+execute 'Register ASP.NET v4 (x64)' do
+  command "#{aspnet_regiis64} -i"
+  only_if { File.exists?(aspnet_regiis64) }
+  action :nothing
 end
 
 service "iis" do


### PR DESCRIPTION
If we install IIS after .NET framework, failing to register ASP.NET will result in non-working installation.

I.e. this happens when running IIS7 recipe on Amazon's EC2 base image for Windows
