### PR TITLE
Correct order for IIS6 Management Compatibility

### DIFF
--- a/recipes/mod_iis6_metabase_compat.rb
+++ b/recipes/mod_iis6_metabase_compat.rb
@@ -23,7 +23,7 @@ include_recipe "iis"
 if Opscode::IIS::Helper.older_than_windows2008r2?
   features = %w{Web-Metabase Web-Mgmt-Compat}
 else
-  features = %w{IIS-Metabase IIS-IIS6ManagementCompatibility}
+  features = %w{IIS-IIS6ManagementCompatibility IIS-Metabase}
 end
 
 features.each do |f|


### PR DESCRIPTION
IIS6 Management Compatibility is required before Metabase.

```
The operation completed but IIS-Metabase feature was not enabled.

Ensure that the following parent feature(s) are enabled first. If they are already enabled, refer to the log file for further diagnostics.

IIS-IIS6ManagementCompatibility
```
