### PR TITLE
Remove non-ASCII character from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Allows easy management of IIS virtual sites (ie vhosts).
 ### Attribute Parameters
 
 - product_id: name attribute. Specifies the ID of a product to install.
-- accept_eula: specifies that WebpiCmdline should Auto-Accept Eula’s. default is false.
+- accept_eula: specifies that WebpiCmdline should Auto-Accept Eula's. default is false.
 
 - site_name: name attribute.
 - site_id: . if not given IIS generates a unique ID for the site


### PR DESCRIPTION
There is a non-ASCII quote in the README file which causes problems with Berkshelf / Ridley.

/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/json-1.8.1/lib/json/common.rb:155:in `encode': "\xE2" on US-ASCII (Encoding::InvalidByteSequenceError)

Easiest fix seems to be to just change the quote :)
