### PR TITLE
fix invalid ASCII in README causing InvalidByteSequenceError 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Allows easy management of IIS virtual sites (ie vhosts).
 ### Attribute Parameters
 
 - product_id: name attribute. Specifies the ID of a product to install.
-- accept_eula: specifies that WebpiCmdline should Auto-Accept Eula’s. default is false.
+- accept_eula: specifies that WebpiCmdline should Auto-Accept Eula's. default is false.
 
 - site_name: name attribute.
 - site_id: . if not given IIS generates a unique ID for the site


### PR DESCRIPTION
When read into metadata.rb on systems without a UTF-8 locale setting, this character bombs Chef runs.
