### PR TITLE
Add win_friendly_path to all appcmd.exe /physicalPath arguments.

### DIFF
--- a/providers/app.rb
+++ b/providers/app.rb
@@ -29,7 +29,7 @@ action :add do
     cmd = "#{appcmd} add app /site.name:\"#{@new_resource.app_name}\""
     cmd << " /path:\"#{@new_resource.path}\""
     cmd << " /applicationPool:\"#{@new_resource.application_pool}\"" if @new_resource.application_pool
-    cmd << " /physicalPath:\"#{@new_resource.physical_path}\"" if @new_resource.physical_path
+    cmd << " /physicalPath:\"#{win_friendly_path(@new_resource.physical_path)}\"" if @new_resource.physical_path
     cmd << " /enabledProtocols:\"#{@new_resource.enabled_protocols}\"" if @new_resource.enabled_protocols
     Chef::Log.debug(cmd)
     shell_out!(cmd)
@@ -50,7 +50,7 @@ action :config do
 
   if @new_resource.physical_path
     cmd = "#{appcmd} set vdir /vdir.name:\"#{vdir_identifier}\""
-    cmd << " /physicalPath:\"#{@new_resource.physical_path}\""
+    cmd << " /physicalPath:\"#{win_friendly_path(@new_resource.physical_path)}\""
     Chef::Log.debug(cmd)
     shell_out!(cmd)
   end

--- a/providers/site.rb
+++ b/providers/site.rb
@@ -64,7 +64,7 @@ action :config do
 
   if @new_resource.path
     cmd = "#{appcmd} set vdir \"#{@new_resource.site_name}/\" "
-    cmd << "/physicalPath:\"#{@new_resource.path}\""
+    cmd << "/physicalPath:\"#{win_friendly_path(@new_resource.path)}\""
     Chef::Log.debug(cmd)
     shell_out!(cmd)
   end


### PR DESCRIPTION
This existed on 1/4 calls - just adding to the rest.  This prevents an
issue on IIS7, which doesn't like forward slashes in this arg.
