### PR TITLE
added param 'source' to specify source to install win features. #209

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,3 +25,5 @@ default['iis']['docroot']    = "#{ENV['SYSTEMDRIVE']}\\inetpub\\wwwroot"
 default['iis']['log_dir']    = "#{ENV['SYSTEMDRIVE']}\\inetpub\\logs\\LogFiles"
 default['iis']['cache_dir']  = "#{ENV['SYSTEMDRIVE']}\\inetpub\\temp"
 default['iis']['components'] = []
+
+default['iis']['source'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ default = Opscode::IIS::Helper.older_than_windows2008r2? ? 'Web-Server' : 'IIS-W
   windows_feature feature do
     action :install
     all !Opscode::IIS::Helper.older_than_windows2012?
-    source node['iis']['source']
+    unless node['iis']['source'].nil?; source node['iis']['source'] end
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,7 @@ default = Opscode::IIS::Helper.older_than_windows2008r2? ? 'Web-Server' : 'IIS-W
   windows_feature feature do
     action :install
     all !Opscode::IIS::Helper.older_than_windows2012?
+    source node['iis']['source']
   end
 end
 


### PR DESCRIPTION
I checked converge with source=nil and source='c:\\sxs' from create and from converged with other value. Checked both chef, 11 and 12 version.

First run with default['iis']['source'] = 'c:\\sxs' (created from separate recipe "iis::prepare"):
~~~
ki converge default-windows-2012r2
-----> Starting Kitchen (v1.4.1)
-----> Converging <default-windows-2012r2>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 3.3.0...
       Removing non-cookbook files before transfer
       Preparing validation.pem
       Preparing client.rb
-----> Chef Omnibus installation detected (11.16.4)
       Transferring files to <default-windows-2012r2>
       Starting Chef Client, version 11.16.4
       resolving cookbooks for run list: ["iis::prepare", "iis::default"]
       Synchronizing Cookbooks:
         - iis
         - windows
         - chef_handler
       Compiling Cookbooks...
       Converging 4 resources
       Recipe: iis::prepare

           - update content in file C:\sxs.zip from e3b0c4 to 3c69b3
           (file sizes exceed 10000000 bytes, diff output suppressed)


             - install version 1.1.7 of package rubyzip

        (up to date)
       Recipe: iis::default


         * service[iis] action enable (up to date)
         * service[iis] action start (up to date)

       Running handlers:
       Running handlers complete
       Chef Client finished, 4/7 resources updated in 456.429627 seconds
       Finished converging <default-windows-2012r2> (8m1.20s).
-----> Kitchen is finished. (8m4.30s)
~~~
Second run with node['iis']['source'] = nil:
~~~
ki converge default-windows-2012r2
-----> Starting Kitchen (v1.4.1)
-----> Converging <default-windows-2012r2>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 3.3.0...
       Removing non-cookbook files before transfer
       Preparing validation.pem
       Preparing client.rb
-----> Chef Omnibus installation detected (11.16.4)
       Transferring files to <default-windows-2012r2>
       Starting Chef Client, version 11.16.4
       resolving cookbooks for run list: ["iis::prepare", "iis::default"]
       Synchronizing Cookbooks:
         - windows
         - chef_handler
         - iis
       Compiling Cookbooks...
       Converging 4 resources
       Recipe: iis::prepare
        (up to date)
         * windows_zipfile[Zipfile sxs] action unzip (skipped due to not_if)
       Recipe: iis::default
        (up to date)
         * service[iis] action enable (up to date)
         * service[iis] action start (up to date)

       Running handlers:
       Running handlers complete
       Chef Client finished, 0/4 resources updated in 29.342409 seconds
       Finished converging <default-windows-2012r2> (0m52.87s).
-----> Kitchen is finished. (0m55.90s)
~~~
Run verify:
~~~
ki verify default-windows-2012r2
-----> Starting Kitchen (v1.4.1)
-----> Setting up <default-windows-2012r2>...
       Finished setting up <default-windows-2012r2> (0m0.00s).
-----> Verifying <default-windows-2012r2>...
       Preparing files for transfer
-----> Installing Busser (busser)
       Successfully installed thor-0.19.0
       Successfully installed busser-0.7.1
       2 gems installed
-----> Setting up Busser
       Creating BUSSER_ROOT in C:\Users\vagrant\AppData\Local\Temp\verifier
       Creating busser binstub
       Installing Busser plugins: busser-pester busser-serverspec
       Plugin pester installed (version 0.0.8)
-----> Running postinstall for pester plugin
-----> [pester] Installing PsGet
       Downloading PsGet from https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1
       PsGet is installed and ready to useUSAGE:
           PS> import-module PsGet
           PS> install-module PsUrl

       For more details:
           get-help install-module
       Or visit http://psget.net
-----> [pester] Installing Pester
       "C:\Users\vagrant\Documents\WindowsPowerShell\Modules" is added to the PSModulePath environment variableModule Pester was successfully installed.       Plugin serverspec in
stalled (version 0.5.7)
-----> Running postinstall for serverspec plugin
       Suite path directory C:/Users/vagrant/AppData/Local/Temp/verifier/suites does not exist, skipping.
       Transferring files to <default-windows-2012r2>
-----> Running pester test suite
-----> [pester] Running




       Describing iis::default
        [+] Should have the Web Server Role 5.14s [+] Should have World Wide Web Publishing Service running 2.29s [+] Should have a default website 1.74s [+] Should have a default
 app pool 507msTests completed in 9.68sPassed: 4 Failed: 0 Skipped: 0 Pending: 0-----> Running serverspec test suite
-----> Installing Serverspec..
-----> serverspec installed (version 2.23.0)

       iis::default
         Windows feature "IIS-WebServerRole"
           should be installed
         Service "World Wide Web Publishing Service"
           should be running
           should have start mode "Automatic"
         IIS Website "Default Web Site"
           should exist
           should be enabled
           should be running
           should be in app pool "DefaultAppPool"

       iis::remove_default_site
         IIS Website "Default Website"
           should not exist
         IIS Application Pool "Default App Pool"
           should not exist

       Finished in 18.34 seconds (files took 2.09 seconds to load)
       9 examples, 0 failures

       C:/opscode/chef/embedded/bin/ruby.exe -IC:/Users/vagrant/AppData/Local/Temp/verifier/suites/serverspec -I'C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/rspec-suppo
rt-3.3.0/lib';'C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/rspec-core-3.3.2/lib' 'C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/rspec-core-3.3.2/exe/rspec' --p
attern 'C:/Users/vagrant/AppData/Local/Temp/verifier/suites/serverspec/**/*_spec.rb' --color --format documentation --default-path C:/Users/vagrant/AppData/Local/Temp/verifier/sui
tes/serverspec
       Finished verifying <default-windows-2012r2> (3m50.96s).
-----> Kitchen is finished. (3m53.99s)
~~~

This is run with latest chef and source = 'c:\\sxs':
~~~
ki converge default-windows-2012r2
-----> Starting Kitchen (v1.4.1)
-----> Converging <default-windows-2012r2>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 3.3.0...
       Removing non-cookbook files before transfer
       Preparing validation.pem
       Preparing client.rb
-----> Chef Omnibus installation detected (install only if missing)
       Transferring files to <default-windows-2012r2>
       Starting Chef Client, version 12.4.1
       [2015-09-04T08:36:13+00:00] WARN: Child with name 'dna.json' found in multiple directories: C:/Users/vagrant/AppData/Local/Temp/kitchen/dna.json and C:/Users/vagrant/AppDat
a/Local/Temp/kitchen/dna.json
       resolving cookbooks for run list: ["iis::default"]
       Synchronizing Cookbooks:
         - iis
         - windows
         - chef_handler
       Compiling Cookbooks...
       [2015-09-04T08:36:14+00:00] WARN: Using an LWRP provider by its name (WindowsFeatureDism) directly is no longer supported in Chef 12 and will be removed.  Use Chef::Provide
rResolver.new(node, resource, action) instead.
       Converging 2 resources
       Recipe: iis::default


         * windows_service[iis] action enable (up to date)
         * windows_service[iis] action start (up to date)

       Running handlers:
       Running handlers complete
       Chef Client finished, 1/3 resources updated in 114.407253 seconds
       Finished converging <default-windows-2012r2> (2m11.68s).
-----> Kitchen is finished. (2m14.65s)
~~~