### PR TITLE
Add back iis pool auto_start handling

### DIFF
--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -142,8 +142,7 @@ def configure
     if iis_version > '7.0'
       is_new_start_mode = new_value?(doc.root, 'APPPOOL/add/@startMode', new_resource.start_mode.to_s)
     end
-    # This isn't currently being used...re-add when needed
-    # is_new_auto_start = new_value?(doc.root, 'APPPOOL/add/@autoStart', new_resource.auto_start.to_s)
+    is_new_auto_start = new_value?(doc.root, 'APPPOOL/add/@autoStart', new_resource.auto_start.to_s)
     is_new_queue_length = new_value?(doc.root, 'APPPOOL/add/@queueLength', new_resource.queue_length.to_s)
     is_new_enable_32_bit_app_on_win_64 = new_value?(doc.root, 'APPPOOL/add/@enable32BitAppOnWin64', new_resource.thirty_two_bit.to_s)
 
@@ -197,6 +196,7 @@ def configure
     @cmd = "#{appcmd(node)} set config /section:applicationPools"
 
     # root items
+    configure_application_pool(is_new_auto_start, "autoStart:#{new_resource.auto_start}")
     if iis_version > '7.0'
       configure_application_pool(is_new_start_mode, "startMode:#{new_resource.start_mode}")
     end


### PR DESCRIPTION
IIS pool `auto_start` setting support has been removed in 85df26049762bc56f0775ea2d98337329a0919a8 - I still don't understand why - so I just add it back :)

cc. @aboten