### PR TITLE
fix of issue #203

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,7 +5,7 @@ driver:
     memory: 4096
 
 provisioner:
-  name: chef_zero
+  name: chef_zero_scheduled_task
 
 platforms:
   #- name: win2012r2-chef11
@@ -32,4 +32,4 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[iis::default]
+      - recipe[iis_test::default]

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ end
 
 group :kitchen_common do
   gem 'test-kitchen', '~> 1.7'
+  gem 'chef-zero-scheduled-task', '~> 0.1.0'
 end
 
 group :kitchen_vagrant do

--- a/test/fixtures/cookbooks/iis_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/iis_test/attributes/default.rb
@@ -1,0 +1,2 @@
+node.default['iis']['components'] = %w(Application-Server-HTTP-Activation)
+

--- a/test/fixtures/cookbooks/iis_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/iis_test/attributes/default.rb
@@ -1,2 +1,1 @@
 node.default['iis']['components'] = %w(Application-Server-HTTP-Activation)
-

--- a/test/fixtures/cookbooks/iis_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/iis_test/recipes/default.rb
@@ -2,3 +2,5 @@
 # Cookbook Name:: iis_test
 # Recipe:: default
 # tests the iis cookbook
+
+include_recipe 'iis::default'


### PR DESCRIPTION
### Description

When IIS is installed thru DISM it requires actual user not only WinRM connection. chef_zero_scheduled_task provisioner is used to achieve this.

### Issues Resolved
issue #203 