### PR TITLE
iis-root default_documents deleted every chef run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the iis cookbook.
 
+## 5.0.7 (2017-03-07)
+- [iis-root default_documents deleted every chef run](#306)
+
 ## 5.0.6 (2017-02-24)
 - [iis_version is not evaluated properly on if statement](#308)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures Microsoft Internet Information Services'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '5.0.6'
+version '5.0.7'
 supports 'windows'
 depends 'windows', '>= 1.34.6'
 source_url 'https://github.com/chef-cookbooks/iis'


### PR DESCRIPTION
Signed-off-by: Justin Schuhmann <jmschu02@gmail.com>

### Description

This fixes an issue with handling default_documents and mime_types

### Issues Resolved

#306 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
