### PR TITLE
Missing quotes on iis_pool command

### DIFF
--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -87,7 +87,7 @@ default_action :add
 
 load_current_value do |desired|
   name desired.name
-  cmd = shell_out("#{appcmd(node)} list apppool #{desired.name}")
+  cmd = shell_out("#{appcmd(node)} list apppool \"#{desired.name}\"")
   # APPPOOL "DefaultAppPool" (MgdVersion:v2.0,MgdMode:Integrated,state:Started)
   Chef::Log.debug("#{desired} list apppool command output: #{cmd.stdout}")
   unless cmd.stderr.empty?


### PR DESCRIPTION
Resolves #354

### Description

Adds missing quotes to `iis_pool` resource command 

### Issues Resolved

#354 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
