### PR TITLE
Fix iis_pool identity_type issue

### DIFF
--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -411,6 +411,7 @@ action_class.class_eval do
       end
     end
 
+    Chef::Log.warn("username: #{new_resource.username} password: #{new_resource.password} identity_type: #{new_resource.identity_type}")
     # Application Pool Identity Settings
     if new_resource.username && new_resource.username != ''
       cmd = default_app_pool_user
@@ -424,12 +425,10 @@ action_class.class_eval do
         Chef::Log.debug(cmd)
         shell_out!(cmd)
       end
-    elsif (new_resource.username || new_resource.username == '') &&
-          (new_resource.password || new_resource.username == '') &&
-          (new_resource.identity_type != 'SpecificUser')
+    elsif new_resource.identity_type != 'SpecificUser'
       converge_if_changed :identity_type do
         cmd = "#{appcmd(node)} set config /section:applicationPools"
-        cmd << " \"/[name='#{new_resource.name}'].processModel.identityType:#{new_resource.identity}\""
+        cmd << " \"/[name='#{new_resource.name}'].processModel.identityType:#{new_resource.identity_type}\""
         Chef::Log.debug(cmd)
         shell_out!(cmd)
       end

--- a/test/cookbooks/test/recipes/pool.rb
+++ b/test/cookbooks/test/recipes/pool.rb
@@ -55,3 +55,8 @@ iis_pool 'My App Pool' do
   pipeline_mode :Integrated
   action [:add, :config, :start]
 end
+
+iis_pool 'test_identity_type' do
+  identity_type :NetworkService
+  action [:add, :config, :start]
+end

--- a/test/integration/pool/controls/pool_spec.rb
+++ b/test/integration/pool/controls/pool_spec.rb
@@ -45,3 +45,9 @@ describe iis_pool('My App Pool') do
   its('managed_pipeline_mode') { should eq 'Integrated' }
   it { should have_name('My App Pool') }
 end
+
+describe iis_pool('test_identity_type') do
+  it { should exist }
+  it { should be_running }
+  its('identity_type') { should eq 'NetworkService' }
+end


### PR DESCRIPTION
### Description

Fixes an issue with `iis_pool` not updating `identity_type` due to a missed `identity` and bad if statement for chef-client 13 since the default isn't empty string on these variables anymore

### Issues Resolved

#360 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
