### PR TITLE
Update iis_vdir name to not require a trailing /

### DIFF
--- a/resources/vdir.rb
+++ b/resources/vdir.rb
@@ -34,7 +34,7 @@ property :allow_sub_dir_config, [true, false], default: true
 default_action :add
 
 load_current_value do |desired|
-  name application_cleanname(desired.name)
+  name application_cleanname(desired.name).end_with?('/') ? application_cleanname(desired.name) : application_cleanname(desired.name) + '/'
   path desired.path
   cmd = shell_out("#{appcmd(node)} list vdir \"#{name.chomp('/') + path}\"")
   Chef::Log.debug("#{desired} list vdir command output: #{cmd.stdout}")
@@ -63,7 +63,7 @@ end
 action :add do
   if !@current_resource.physical_path
     converge_by "Created the VDIR - \"#{new_resource}\"" do
-      cmd = "#{appcmd(node)} add vdir /app.name:\"#{new_resource.name}\""
+      cmd = "#{appcmd(node)} add vdir /app.name:\"#{vdir_identifier}\""
       cmd << " /path:\"#{new_resource.path}\""
       cmd << " /physicalPath:\"#{windows_cleanpath(new_resource.physical_path)}\""
       cmd << " /userName:\"#{new_resource.username}\"" if new_resource.username
@@ -125,6 +125,10 @@ end
 
 action_class.class_eval do
   def application_identifier
-    new_resource.name.chomp('/') + new_resource.path
+    vdir_identifier.chomp('/') + new_resource.path
+  end
+
+  def vdir_identifier
+    new_resource.name.end_with?('/') ? new_resource.name : new_resource.name + '/'
   end
 end

--- a/test/cookbooks/test/recipes/vdir.rb
+++ b/test/cookbooks/test/recipes/vdir.rb
@@ -26,6 +26,10 @@ directory "#{node['iis']['docroot']}\\vdir_test" do
   recursive true
 end
 
+directory "#{node['iis']['docroot']}\\foo" do
+  recursive true
+end
+
 iis_pool 'DefaultAppPool' do
   pipeline_mode :Classic
   action :add
@@ -45,5 +49,12 @@ iis_vdir 'Default Web Site/' do
   password 'vagrant'
   logon_method :ClearText
   allow_sub_dir_config false
+  action [:add, :config]
+end
+
+iis_vdir 'Creating vDir /foo for Sitename' do
+  name 'Default Web Site'
+  path '/foo'
+  physical_path "#{node['iis']['docroot']}\\foo"
   action [:add, :config]
 end

--- a/test/integration/vdir/controls/vdir_spec.rb
+++ b/test/integration/vdir/controls/vdir_spec.rb
@@ -19,3 +19,9 @@ describe iis_vdir('Default Web Site', '/vdir_test') do
   it { should have_logon_method('ClearText') }
   it { should have_allow_sub_dir_config(false) }
 end
+
+describe iis_vdir('Default Web Site', '/foo') do
+  it { should exist }
+  it { should have_path('/foo') }
+  it { should have_physical_path('C:\\inetpub\\wwwroot\\foo') }
+end


### PR DESCRIPTION
### Description

Allows `iis_vdir` to not require a trailing / in the `name` property

### Issues Resolved

#361 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
