### PR TITLE
Fix issue with guard clause missing on check

### DIFF
--- a/resources/app.rb
+++ b/resources/app.rb
@@ -33,7 +33,7 @@ default_action :add
 load_current_value do |desired|
   site_name desired.site_name
   # Sanitize physical path
-  desired.physical_path = windows_cleanpath(desired.physical_path)
+  desired.physical_path = windows_cleanpath(desired.physical_path) if desired.physical_path
   cmd = shell_out("#{appcmd(node)} list app \"#{desired.site_name}#{desired.path}\"")
   Chef::Log.debug("#{appcmd(node)} list app command output: #{cmd.stdout}")
   if cmd.stderr.empty?

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -42,8 +42,8 @@ default_action :add
 load_current_value do |desired|
   site_name desired.site_name
   # Sanitize windows file system path
-  desired.path = windows_cleanpath(desired.path)
-  desired.log_directory = windows_cleanpath(desired.log_directory)
+  desired.path = windows_cleanpath(desired.path) if desired.path
+  desired.log_directory = windows_cleanpath(desired.log_directory) if desired.log_directory
   cmd = shell_out "#{appcmd(node)} list site \"#{site_name}\""
   Chef::Log.debug(appcmd(node))
   # 'SITE "Default Web Site" (id:1,bindings:http/*:80:,state:Started)'

--- a/resources/vdir.rb
+++ b/resources/vdir.rb
@@ -37,7 +37,7 @@ load_current_value do |desired|
   # Sanitize Application Name
   desired.application_name = application_cleanname(desired.application_name)
   # Sanitize Physical Path
-  desired.physical_path = windows_cleanpath(desired.physical_path)
+  desired.physical_path = windows_cleanpath(desired.physical_path) if desired.physical_path
   application_name desired.application_name
   path desired.path
   cmd = shell_out("#{appcmd(node)} list vdir \"#{application_name.chomp('/') + path}\"")

--- a/test/cookbooks/test/recipes/site.rb
+++ b/test/cookbooks/test/recipes/site.rb
@@ -26,6 +26,14 @@ directory "#{node['iis']['docroot']}\\site_test2" do
   recursive true
 end
 
+iis_site 'to_be_deleted' do
+  application_pool 'DefaultAppPool'
+  path "#{node['iis']['docroot']}/site_test"
+  host_header 'localhost'
+  port 8081
+  action [:add, :start]
+end
+
 iis_site 'test' do
   application_pool 'DefaultAppPool'
   path "#{node['iis']['docroot']}/site_test"
@@ -39,4 +47,8 @@ iis_site 'test2' do
   host_header 'localhost'
   port 8080
   action [:add, :start]
+end
+
+iis_site 'to_be_deleted' do
+  action [:stop, :delete]
 end

--- a/test/integration/site/site_spec.rb
+++ b/test/integration/site/site_spec.rb
@@ -35,3 +35,8 @@ describe iis_site('test2') do
   it { should have_app_pool('DefaultAppPool') }
   its('bindings') { should eq ['http *:8080:localhost'] }
 end
+
+describe iis_site('to_be_deleted') do
+  it { should_not exist }
+  it { should_not be_running }
+end


### PR DESCRIPTION
Signed-off-by: Justin Schuhmann <jmschu02@gmail.com>

### Description

Adds guard class to all `windows_cleanpath` additions, since they are optional properties

### Issues Resolved

#377 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
