### PR TITLE
Adds the ability to define recycling schedule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,4 +9,4 @@ Style/GuardClause:
 Style/PredicateName:
   Exclude:
     - 'spec/**/*'
-    - 'test/integration/**/*
+    - 'test/integration/**/*'

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Creates an application pool in IIS.
 - `log_event_on_recycle` - configure IIS to log an event when one or more of the following configured events cause an application pool to recycle (for additional information about [logging events] (<https://technet.microsoft.com/en-us/library/cc771318%28v=ws.10%29.aspx>). - default is 'Time, Requests, Schedule, Memory, IsapiUnhealthy, OnDemand, ConfigChange, PrivateMemory' - optional
 - `recycle_schedule_clear` - specifies a pool to clear all scheduled recycle times, [true,false] Default is false - optional
 - `recycle_after_time` - specifies a pool to recycle at regular time intervals, d.hh:mm:ss, d optional
-- `recycle_at_time` - schedule a pool to recycle at a specific time, d.hh:mm:ss, d optional
+- `recycle_at_time` - schedule a pool to recycle at specific times. Single value or array accepted. `hh:mm:ss` or `['hh:mm:ss','hh:mm:ss']`, optional
 - `private_memory` - specifies the amount of private memory (in kilobytes) after which you want the pool to recycle
 - `virtual_memory` - specifies the amount of virtual memory (in kilobytes) after which you want the pool to recycle
 

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -87,6 +87,10 @@ module Opscode
         XPath.first(document, xpath).to_s
       end
 
+      def get_value(document, xpath)
+        XPath.match(document, xpath)
+      end
+
       def bool(value)
         value == 'true'
       end

--- a/test/cookbooks/test/recipes/pool.rb
+++ b/test/cookbooks/test/recipes/pool.rb
@@ -40,6 +40,7 @@ iis_pool 'testapppool' do
   pipeline_mode :Integrated
   start_mode :OnDemand
   identity_type :SpecificUser
+  recycle_at_time ['06:00:00', '14:00:00', '17:00:00']
   username "#{node['hostname']}\\vagrant"
   password 'vagrant'
   action [:add, :config]

--- a/test/integration/pool/controls/pool_spec.rb
+++ b/test/integration/pool/controls/pool_spec.rb
@@ -26,6 +26,7 @@ describe iis_pool('testapppool') do
   it { should have_name('testapppool') }
   its('start_mode') { should eq 'OnDemand' }
   its('identity_type') { should eq 'SpecificUser' }
+  its('recycle_at_time') { should eq ['06:00:00', '14:00:00', '17:00:00'] }
   its('username') { should include('\\vagrant') }
   its('password') { should eq 'vagrant' }
 end

--- a/test/integration/pool/libraries/iis_pool.rb
+++ b/test/integration/pool/libraries/iis_pool.rb
@@ -97,6 +97,10 @@ class IisPool < Inspec.resource(1)
     iis_pool[:process_model][:password]
   end
 
+  def recycle_at_time
+    iis_pool[:recycling][:periodic_restart][:schedule]
+  end
+
   def exists?
     !iis_pool.nil? && !iis_pool[:name].nil?
   end


### PR DESCRIPTION
### Description

Adds the ability to define multiple recycle times on an app pool.

I would have preferred to call the property `periodic_restart_schedule` but to maintain backwards compatibility continued to use `recycle_at_time`.

The property accepts both a string and array which are coerced into an array when being used.

### Issues Resolved

#194 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
