### PR TITLE
Rename `recycle_at_time` to `periodic_restart_schedule`

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Creates an application pool in IIS.
 - `log_event_on_recycle` - configure IIS to log an event when one or more of the following configured events cause an application pool to recycle (for additional information about [logging events] (<https://technet.microsoft.com/en-us/library/cc771318%28v=ws.10%29.aspx>). - default is 'Time, Requests, Schedule, Memory, IsapiUnhealthy, OnDemand, ConfigChange, PrivateMemory' - optional
 - `recycle_schedule_clear` - specifies a pool to clear all scheduled recycle times, [true,false] Default is false - optional
 - `recycle_after_time` - specifies a pool to recycle at regular time intervals, d.hh:mm:ss, d optional
-- `recycle_at_time` - schedule a pool to recycle at specific times. Single value or array accepted. `hh:mm:ss` or `['hh:mm:ss','hh:mm:ss']`, optional
+- `periodic_restart_schedule` - schedule a pool to recycle at specific times. Single value or array accepted. `hh:mm:ss` or `['hh:mm:ss','hh:mm:ss']`, optional
 - `private_memory` - specifies the amount of private memory (in kilobytes) after which you want the pool to recycle
 - `virtual_memory` - specifies the amount of virtual memory (in kilobytes) after which you want the pool to recycle
 

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -57,7 +57,7 @@ property :disallow_overlapping_rotation, [true, false], default: false
 property :recycle_schedule_clear, [true, false], default: false
 property :log_event_on_recycle, String, default: node['iis']['recycle']['log_events']
 property :recycle_after_time, String
-property :recycle_at_time, [Array, String], default: [], coerce: proc { |v| [*v].sort }
+property :periodic_restart_schedule, [Array, String], default: [], coerce: proc { |v| [*v].sort }
 property :private_memory, Integer, coerce: proc { |v| v.to_i }
 property :virtual_memory, Integer, coerce: proc { |v| v.to_i }
 
@@ -144,7 +144,7 @@ load_current_value do |desired|
     disallow_overlapping_rotation bool(value(doc.root, 'APPPOOL/add/recycling/@disallowOverlappingRotation'))
     disallow_rotation_on_config_change bool(value(doc.root, 'APPPOOL/add/recycling/@disallowRotationOnConfigChange'))
     recycle_after_time value doc.root, 'APPPOOL/add/recycling/periodicRestart/@time'
-    recycle_at_time get_value(doc.root, 'APPPOOL/add/recycling/periodicRestart/schedule/add/@value').map(&:value)
+    periodic_restart_schedule get_value(doc.root, 'APPPOOL/add/recycling/periodicRestart/schedule/add/@value').map(&:value)
     private_memory value(doc.root, 'APPPOOL/add/recycling/periodicRestart/@privateMemory').to_i
     virtual_memory value(doc.root, 'APPPOOL/add/recycling/periodicRestart/@memory').to_i
     log_event_on_recycle value doc.root, 'APPPOOL/add/recycling/@logEventOnRecycle'
@@ -323,14 +323,14 @@ action_class.class_eval do
       cmd << configure_application_pool("processModel.pingResponseTime:#{new_resource.ping_response_time}")
     end
 
-    converge_if_changed :recycle_at_time do
+    converge_if_changed :periodic_restart_schedule do
       # Remove the values that are no longer required
-      ([*current_resource.recycle_at_time] - [*new_resource.recycle_at_time]).each do |periodic_restart|
+      ([*current_resource.periodic_restart_schedule] - [*new_resource.periodic_restart_schedule]).each do |periodic_restart|
         cmd << configure_application_pool("recycling.periodicRestart.schedule.[value='#{periodic_restart}']", '-')
       end
 
       # Add the new values
-      ([*new_resource.recycle_at_time] - [*current_resource.recycle_at_time]).each do |periodic_restart|
+      ([*new_resource.periodic_restart_schedule] - [*current_resource.periodic_restart_schedule]).each do |periodic_restart|
         cmd << configure_application_pool("recycling.periodicRestart.schedule.[value='#{periodic_restart}']", '+')
       end
     end

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -83,6 +83,9 @@ property :smp_processor_affinity_mask_2, Float, default: 4_294_967_295.0, coerce
 # internally used for the state of the pool [Starting, Started, Stopping, Stopped, Unknown, Undefined value]
 property :running, [true, false], desired_state: true
 
+# Alias property until the next major release
+alias_method :recycle_at_time, :periodic_restart_schedule
+
 default_action :add
 
 load_current_value do |desired|

--- a/test/cookbooks/test/recipes/pool.rb
+++ b/test/cookbooks/test/recipes/pool.rb
@@ -40,7 +40,7 @@ iis_pool 'testapppool' do
   pipeline_mode :Integrated
   start_mode :OnDemand
   identity_type :SpecificUser
-  recycle_at_time ['06:00:00', '14:00:00', '17:00:00']
+  periodic_restart_schedule ['06:00:00', '14:00:00', '17:00:00']
   username "#{node['hostname']}\\vagrant"
   password 'vagrant'
   action [:add, :config]

--- a/test/integration/pool/controls/pool_spec.rb
+++ b/test/integration/pool/controls/pool_spec.rb
@@ -26,7 +26,7 @@ describe iis_pool('testapppool') do
   it { should have_name('testapppool') }
   its('start_mode') { should eq 'OnDemand' }
   its('identity_type') { should eq 'SpecificUser' }
-  its('recycle_at_time') { should eq ['06:00:00', '14:00:00', '17:00:00'] }
+  its('periodic_restart_schedule') { should eq ['06:00:00', '14:00:00', '17:00:00'] }
   its('username') { should include('\\vagrant') }
   its('password') { should eq 'vagrant' }
 end

--- a/test/integration/pool/libraries/iis_pool.rb
+++ b/test/integration/pool/libraries/iis_pool.rb
@@ -97,7 +97,7 @@ class IisPool < Inspec.resource(1)
     iis_pool[:process_model][:password]
   end
 
-  def recycle_at_time
+  def periodic_restart_schedule
     iis_pool[:recycling][:periodic_restart][:schedule]
   end
 


### PR DESCRIPTION
### Description

Renames `recycle_at_time` to `periodic_restart_schedule` as it's a bit more accurate.

Still need to add back `recycle_at_time` so it can be used until the next major release; is there a way we can alias the property and mark it as deprecated?

### Issues Resolved

Performs the rename mentioned in #397 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
