### PR TITLE
Bump version to v6.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the iis cookbook.
 
+## 6.8.0 (2017-10-18)
+
+- [Adds `periodic_restart_schedule` the ability to define multiple recycle times on an app pool](https://github.com/chef-cookbooks/iis/pull/397)
+
 ## 6.7.3 (2017-09-08)
 
 - Add better documentation for the options parameter (#383)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs/Configures Microsoft Internet Information Services'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '6.7.3'
+version '6.8.0'
 supports 'windows'
 depends 'windows', '>= 2.0'
 source_url 'https://github.com/chef-cookbooks/iis'


### PR DESCRIPTION
Signed-off-by: Justin Schuhmann <jmschu02@gmail.com>

### Description

- [Adds `periodic_restart_schedule` the ability to define multiple recycle times on an app pool](https://github.com/chef-cookbooks/iis/pull/397)

### Issues Resolved

#194 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
