### PR TITLE
remove :name property

### DIFF
--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -24,7 +24,6 @@ include Opscode::IIS::Helper
 include Opscode::IIS::Processors
 
 # root
-property :name, String, name_property: true
 property :no_managed_code, [true, false], default: false
 property :pipeline_mode, [Symbol, String], equal_to: [:Integrated, :Classic], coerce: proc { |v| v.to_sym }
 property :runtime_version, String


### PR DESCRIPTION
### Description

remove :name property from `app_pool` resource.

The `:name` property is inherited from `Chef::Resource`, so
declaring it here is pointless.

Reference: https://github.com/chef/chef/blob/master/lib/chef/resource.rb#L87

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
