### PR TITLE
revert back to :name property (instead of :pool_name)

### DIFF
--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -24,7 +24,6 @@ include Opscode::IIS::Helper
 include Opscode::IIS::Processors
 
 # root
-property :pool_name, String, name_property: true
 property :no_managed_code, [true, false], default: false
 property :pipeline_mode, [Symbol, String], equal_to: [:Integrated, :Classic], coerce: proc { |v| v.to_sym }
 property :runtime_version, String
@@ -89,8 +88,8 @@ alias_method :recycle_at_time, :periodic_restart_schedule
 default_action :add
 
 load_current_value do |desired|
-  pool_name desired.pool_name
-  cmd = shell_out("#{appcmd(node)} list apppool \"#{desired.pool_name}\"")
+  name desired.name
+  cmd = shell_out("#{appcmd(node)} list apppool \"#{desired.name}\"")
   # APPPOOL "DefaultAppPool" (MgdVersion:v2.0,MgdMode:Integrated,state:Started)
   Chef::Log.debug("#{desired} list apppool command output: #{cmd.stdout}")
   unless cmd.stderr.empty?
@@ -99,7 +98,7 @@ load_current_value do |desired|
   end
 
   result = cmd.stdout.gsub(/\r\n?/, "\n") # ensure we have no carriage returns
-  result = result.match(/^APPPOOL\s\"(#{desired.pool_name})\"\s\(MgdVersion:(.*),MgdMode:(.*),state:(.*)\)$/i)
+  result = result.match(/^APPPOOL\s\"(#{desired.name})\"\s\(MgdVersion:(.*),MgdMode:(.*),state:(.*)\)$/i)
   Chef::Log.debug("#{desired} current_resource match output: #{result}")
   unless result
     running false
@@ -107,7 +106,7 @@ load_current_value do |desired|
   end
 
   running result[4] =~ /Started/ ? true : false
-  cmd_current_values = "#{appcmd(node)} list apppool \"#{desired.pool_name}\" /config:* /xml"
+  cmd_current_values = "#{appcmd(node)} list apppool \"#{desired.name}\" /config:* /xml"
   Chef::Log.debug(cmd_current_values)
   cmd_current_values = shell_out(cmd_current_values)
   if cmd_current_values.stderr.empty?
@@ -180,7 +179,7 @@ action :add do
     Chef::Log.debug("#{new_resource} pool already exists - nothing to do")
   else
     converge_by "Created Application Pool \"#{new_resource}\"" do
-      cmd = "#{appcmd(node)} add apppool /name:\"#{new_resource.pool_name}\""
+      cmd = "#{appcmd(node)} add apppool /name:\"#{new_resource.name}\""
       if new_resource.no_managed_code
         cmd << ' /managedRuntimeVersion:'
       elsif new_resource.runtime_version
@@ -202,7 +201,7 @@ end
 action :delete do
   if exists
     converge_by "Deleted Application Pool \"#{new_resource}\"" do
-      shell_out!("#{appcmd(node)} delete apppool \"#{new_resource.pool_name}\"")
+      shell_out!("#{appcmd(node)} delete apppool \"#{new_resource.name}\"")
     end
   else
     Chef::Log.debug("#{new_resource} pool does not exist - nothing to do")
@@ -212,7 +211,7 @@ end
 action :start do
   if exists && !current_resource.running
     converge_by "Started Application Pool \"#{new_resource}\"" do
-      shell_out!("#{appcmd(node)} start apppool \"#{new_resource.pool_name}\"")
+      shell_out!("#{appcmd(node)} start apppool \"#{new_resource.name}\"")
     end
   else
     Chef::Log.debug("#{new_resource} already running - nothing to do")
@@ -222,7 +221,7 @@ end
 action :stop do
   if exists && current_resource.running
     converge_by "Stopped Application Pool \"#{new_resource}\"" do
-      shell_out!("#{appcmd(node)} stop apppool \"#{new_resource.pool_name}\"")
+      shell_out!("#{appcmd(node)} stop apppool \"#{new_resource.name}\"")
     end
   else
     Chef::Log.debug("#{new_resource} already stopped - nothing to do")
@@ -232,9 +231,9 @@ end
 action :restart do
   if exists
     converge_by "Restarted Application Pool \"#{new_resource}\"" do
-      shell_out!("#{appcmd(node)} stop APPPOOL \"#{new_resource.pool_name}\"") if current_resource.running
+      shell_out!("#{appcmd(node)} stop APPPOOL \"#{new_resource.name}\"") if current_resource.running
       sleep 2
-      shell_out!("#{appcmd(node)} start APPPOOL \"#{new_resource.pool_name}\"")
+      shell_out!("#{appcmd(node)} start APPPOOL \"#{new_resource.name}\"")
     end
   end
 end
@@ -242,7 +241,7 @@ end
 action :recycle do
   if exists
     converge_by "Recycled Application Pool \"#{new_resource}\"" do
-      shell_out!("#{appcmd(node)} recycle APPPOOL \"#{new_resource.pool_name}\"") if current_resource.running
+      shell_out!("#{appcmd(node)} recycle APPPOOL \"#{new_resource.name}\"") if current_resource.running
     end
   end
 end
@@ -418,10 +417,10 @@ action_class.class_eval do
     if new_resource.username && new_resource.username != ''
       cmd = default_app_pool_user
       converge_if_changed :username do
-        cmd << " \"/[name='#{new_resource.pool_name}'].processModel.userName:#{new_resource.username}\""
+        cmd << " \"/[name='#{new_resource.name}'].processModel.userName:#{new_resource.username}\""
       end
       converge_if_changed :password do
-        cmd << " \"/[name='#{new_resource.pool_name}'].processModel.password:#{new_resource.password}\""
+        cmd << " \"/[name='#{new_resource.name}'].processModel.password:#{new_resource.password}\""
       end
       if cmd != default_app_pool_user
         converge_by "Configured Application Pool Identity Settings \"#{new_resource}\"" do
@@ -432,7 +431,7 @@ action_class.class_eval do
     elsif new_resource.identity_type != 'SpecificUser'
       converge_if_changed :identity_type do
         cmd = "#{appcmd(node)} set config /section:applicationPools"
-        cmd << " \"/[name='#{new_resource.pool_name}'].processModel.identityType:#{new_resource.identity_type}\""
+        cmd << " \"/[name='#{new_resource.name}'].processModel.identityType:#{new_resource.identity_type}\""
         Chef::Log.debug(cmd)
         shell_out!(cmd)
       end
@@ -441,10 +440,10 @@ action_class.class_eval do
 
   def default_app_pool_user
     cmd_default = "#{appcmd(node)} set config /section:applicationPools"
-    cmd_default << " \"/[name='#{new_resource.pool_name}'].processModel.identityType:SpecificUser\""
+    cmd_default << " \"/[name='#{new_resource.name}'].processModel.identityType:SpecificUser\""
   end
 
   def configure_application_pool(config, add_remove = '')
-    " \"/#{add_remove}[name='#{new_resource.pool_name}'].#{config}\""
+    " \"/#{add_remove}[name='#{new_resource.name}'].#{config}\""
   end
 end


### PR DESCRIPTION
### Description

revert back to :name property (instead of :pool_name)

this is more natural and isn't redundant

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
