### PR TITLE
Update mod_tracing.rb feature capitalization

### DIFF
--- a/recipes/mod_tracing.rb
+++ b/recipes/mod_tracing.rb
@@ -23,7 +23,7 @@ include_recipe 'iis'
 feature = if Opscode::IIS::Helper.older_than_windows2008r2?
             'Web-Http-Tracing'
           else
-            'IIS-HTTPTracing'
+            'IIS-HttpTracing'
           end
 
 windows_feature feature do


### PR DESCRIPTION
The feature is: `IIS-HttpTracing` per: https://docs.microsoft.com/en-us/iis/install/installing-iis-7/understanding-setup-in-iis  

Thus this fails on windows versions that have case sensitive feature installation (windows 7 for example).

### Description

This change allows http tracing to be installed on windows 7.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

**SIGNOFF** - Obvious fix. 