### PR TITLE
Inform OHAI of newly registered aspnet_state service

### DIFF
--- a/recipes/mod_aspnet45.rb
+++ b/recipes/mod_aspnet45.rb
@@ -21,6 +21,10 @@
 include_recipe 'iis'
 include_recipe 'iis::mod_isapi'
 
+ohai 'reload' do
+  action :nothing
+end
+
 features = if Opscode::IIS::Helper.older_than_windows2008r2?
              %w(NET-Framework)
            else
@@ -30,5 +34,6 @@ features = if Opscode::IIS::Helper.older_than_windows2008r2?
 features.each do |feature|
   windows_feature feature do
     action :install
+    notifies :reload, 'ohai[reload]', :immediately
   end
 end


### PR DESCRIPTION
### Description

I'd like to automatically enable aspnet_state upon installation. Currently, OHAI isn't informed that a new service is installed so the logic doesn't work until second run.

Example code
```
service 'aspnet_state' do
  action [:enable, :start]
end
```