### PR TITLE
Fix log_directory issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the iis cookbook.
 
+## 6.8.1 (2018-04-03)
+
+- Fixed site resource defaulting the log_directory when not specified, thus no longer inheriting the server default
+
 ## 6.8.0 (2017-10-18)
 
 - [Adds `periodic_restart_schedule` the ability to define multiple recycle times on an app pool](https://github.com/chef-cookbooks/iis/pull/397)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Installs and configures Microsoft Internet Information Services (IIS) 7.0 and la
 - `node['iis']['conf_dir']` - location where main IIS configs lives. default is `%WINDIR%\System32\inetsrv\config`
 - `node['iis']['pubroot']` - . default is `%SYSTEMDRIVE%\inetpub`
 - `node['iis']['docroot']` - IIS web site home directory. default is `%SYSTEMDRIVE%\inetpub\wwwroot`
-- `node['iis']['log_dir']` - location of IIS logs. default is `%SYSTEMDRIVE%\inetpub\logs\LogFiles`
 - `node['iis']['cache_dir']` - location of cached data. default is `%SYSTEMDRIVE%\inetpub\temp`
 
 ## Resource/Provider

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,6 @@ default['iis']['home']       = "#{ENV['WINDIR']}\\System32\\inetsrv"
 default['iis']['conf_dir']   = "#{ENV['WINDIR']}\\System32\\inetsrv\\config"
 default['iis']['pubroot']    = "#{ENV['SYSTEMDRIVE']}\\inetpub"
 default['iis']['docroot']    = "#{ENV['SYSTEMDRIVE']}\\inetpub\\wwwroot"
-default['iis']['log_dir']    = "#{ENV['SYSTEMDRIVE']}\\inetpub\\logs\\LogFiles"
 default['iis']['cache_dir']  = "#{ENV['SYSTEMDRIVE']}\\inetpub\\temp"
 default['iis']['components'] = []
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs/Configures Microsoft Internet Information Services'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '6.8.0'
+version '6.8.1'
 supports 'windows'
 depends 'windows', '>= 3.3.0'
 source_url 'https://github.com/chef-cookbooks/iis'

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -32,7 +32,7 @@ property    :host_header, String
 property    :bindings, String
 property    :application_pool, String
 property    :options, String, default: ''
-property    :log_directory, String, default: node['iis']['log_dir']
+property    :log_directory, String
 property    :log_period, [Symbol, String], equal_to: [:Daily, :Hourly, :MaxSize, :Monthly, :Weekly], default: :Daily, coerce: proc { |v| v.to_sym }
 property    :log_truncsize, Integer, default: 1_048_576
 property    :running, [true, false], desired_state: true


### PR DESCRIPTION
Fixed site resource defaulting the log_directory when not specified, thus no longer inheriting the server default.

### Issues Resolved
#417 
