### PR TITLE
Set install_method for iis to be powershell - Relevant only for chef client 13

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs/Configures Microsoft Internet Information Services'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '6.8.1'
+version '6.8.2'
 supports 'windows'
 depends 'windows', '>= 3.3.0'
 source_url 'https://github.com/chef-cookbooks/iis'


### PR DESCRIPTION
### Description
Changes to the windows cookbook v3.0.0 has caused windows_feature to install features using dism as the default method. However, not all machines have the feature enabled by default on startup. The install then "silently fails" and continues on past the feature installation, and bugs out when trying to start the Service W3SVC. This PR fixes this problem by installing IIS using the powershell install method, which will install IIS, and "enable" any auxiliary IIS features - thereby allowing for a default dism install for the rest. Note that this is only an issue for chef client 13, as in chef client 14, AFAIK the default windows_feature install method is powershell, not dism.

### Issues Resolved
https://github.com/chef-cookbooks/iis/issues/281
https://github.com/chef-cookbooks/iis/issues/280

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
