### PR TITLE
Explicitly nominate install_method

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -25,6 +25,7 @@ property :additional_components, Array, default: []
 action :install do
   windows_feature ['IIS-WebServerRole'] + new_resource.additional_components do
     action :install
+    install_method :windows_feature_powershell
     all !IISCookbook::Helper.older_than_windows2012?
     source new_resource.source unless new_resource.source.nil?
   end


### PR DESCRIPTION


### Description

Forces installation of IIS using Powershell rather than DISM
Without this, the Windows cookbook defaults to installing using dism.exe when available, causing the converge to fail due to an invalid feature name.
