### PR TITLE
Allow add action in iis_config_property to support multiple properties

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -87,5 +87,14 @@ module IISCookbook
       end
       @iis_version.to_f
     end
+
+    def to_powershell_hash(hash)
+      return unless hash.is_a?(Hash)
+
+      psh_hash = ''
+      hash.each { |k, v| psh_hash << "\'#{k}\' = \'#{v}\';" }
+
+      "@{ #{psh_hash} }"
+    end
   end
 end

--- a/resources/config_property.rb
+++ b/resources/config_property.rb
@@ -62,7 +62,7 @@ action :add do
     property_is_set?(:location)
 
   escaped_filter = new_resource.filter.gsub('{', '{{').gsub('}', '}}')
-  add_cmd = "Add-WebConfigurationProperty -ErrorAction Stop -PSPath #{new_resource.ps_path} #{location_param}"\
+  add_cmd = "Add-WebConfigurationProperty -ErrorAction Stop -PSPath #{new_resource.ps_path} #{location_param} "\
     "-Filter \"#{escaped_filter}\" -Name \".\""
 
   # powershell doesn't like { or } in xpath values (e.g. server variables)

--- a/resources/config_property.rb
+++ b/resources/config_property.rb
@@ -18,13 +18,17 @@
 #
 # Configures an IIS property (using powershell for idempotence)
 
+include IISCookbook::Helper
+
 property :property, String, name_property: true
 property :ps_path, String, required: true
 property :location, String
 property :filter, String, required: true
-property :value, [String, Integer], required: true
+property :value, [String, Integer, Hash], required: true
 
 action :set do
+  raise 'Set action does not support a Hash type for the value property' if new_resource.value.is_a?(Hash)
+
   location_param = "-location \"#{new_resource.location}\"" if
     property_is_set?(:location)
 
@@ -36,6 +40,7 @@ action :set do
                     else
                       "\"#{new_resource.value}\""
                     end
+
   powershell_script "Set #{new_resource.ps_path}#{new_resource.location}\
 /#{escaped_filter}/#{new_resource.property}" do
     code <<-EOH
@@ -56,27 +61,43 @@ action :add do
   location_param = "-location \"#{new_resource.location}\"" if
     property_is_set?(:location)
 
-  # powershell doesn't like { or } in xpath values (e.g. server variables)
-  escaped_value = new_resource.value.gsub('{', '{{').gsub('}', '}}')
   escaped_filter = new_resource.filter.gsub('{', '{{').gsub('}', '}}')
+  add_cmd = "Add-WebConfigurationProperty -ErrorAction Stop -PSPath #{new_resource.ps_path} #{location_param}"\
+    "-Filter \"#{escaped_filter}\" -Name \".\""
+
+  # powershell doesn't like { or } in xpath values (e.g. server variables)
+  if new_resource.value.is_a?(Hash)
+    add_cmd << " -Value #{to_powershell_hash(new_resource.value)}"
+    guard_xpath = ''
+
+    new_resource.value.each_with_index do |(k, v), idx|
+      escaped_value = v.gsub('{', '{{').gsub('}', '}}')
+      guard_xpath << "@#{k}=\'#{escaped_value}\'"
+      guard_xpath << ' and ' unless idx == new_resource.value.size - 1
+    end
+
+    guard_xpath = "*[#{guard_xpath}]"
+  else
+    escaped_value = new_resource.value.gsub('{', '{{').gsub('}', '}}')
+    add_cmd = "#{add_cmd} -Value @{ #{new_resource.property} = '#{new_resource.value}'; }"
+    guard_xpath = "*[@#{new_resource.property}='#{escaped_value}']"
+  end
+
+  guard_cmd = <<-EOH
+  (Get-WebConfiguration -PSPath "#{new_resource.ps_path}" #{location_param} \
+  -Filter \"#{escaped_filter}/#{guard_xpath}\" -ErrorAction Stop) -eq $null
+  EOH
 
   powershell_script "Set #{new_resource.ps_path}#{new_resource.location}\
 /#{escaped_filter}/#{new_resource.property}" do
-    code <<-EOH
-    Add-WebConfigurationProperty -pspath "#{new_resource.ps_path}" \
-    #{location_param} -filter "#{escaped_filter}" \
-    -name "." -value @{ #{new_resource.property} = '#{new_resource.value}'; } \
-    -ErrorAction Stop
-    EOH
-    only_if <<-EOH
-    (Get-WebConfiguration -pspath "#{new_resource.ps_path}" #{location_param} \
-    -filter "#{escaped_filter}/*[@#{new_resource.property}='#{escaped_value}']" \
-    -ErrorAction Stop) -eq $null
-    EOH
+    code add_cmd
+    only_if guard_cmd
   end
 end
 
 action :remove do
+  raise 'Remove action does not support a Hash type for the value property' if new_resource.value.is_a?(Hash)
+
   location_param = "-location \"#{new_resource.location}\"" if
     property_is_set?(:location)
 

--- a/test/cookbooks/test/recipes/config_property.rb
+++ b/test/cookbooks/test/recipes/config_property.rb
@@ -55,9 +55,21 @@ iis_config_property 'Add X-Xss-Protection' do
   value     'X-Xss-Protection'
   action    :add
 end
+
 iis_config_property 'Set X-Xss-Protection' do
   ps_path   'MACHINE/WEBROOT/APPHOST'
   filter    "system.webServer/httpProtocol/customHeaders/add[@name='X-Xss-Protection']"
   property  'value'
   value     '1; mode=block'
+end
+
+# Set HTTP request filtering
+iis_config_property 'Add HTTP Trace Method' do
+  ps_path 'MACHINE/WEBROOT/APPHOST'
+  filter 'system.webServer/security/requestFiltering/verbs'
+  value(
+    verb: 'TRACE',
+    allowed: 'False'
+  )
+  action :add
 end

--- a/test/integration/config_property/config_property_spec.rb
+++ b/test/integration/config_property/config_property_spec.rb
@@ -19,7 +19,7 @@ control 'config_property' do
 
   describe powershell("(Get-WebConfigurationProperty -PSPath \"MACHINE/WEBROOT/APPHOST\" \
                       -filter \"/system.webServer/security/requestFiltering/verbs/add\" \
-                      -Name \"verb\").Value")
+                      -Name \"verb\").Value") do
     its('stdout') { should eq "TRACE"}
   end
 end

--- a/test/integration/config_property/config_property_spec.rb
+++ b/test/integration/config_property/config_property_spec.rb
@@ -16,4 +16,10 @@ control 'config_property' do
                       -Name \"value\").value") do
     its('stdout') { should eq "1; mode=block\r\n" }
   end
+
+  describe powershell("(Get-WebConfigurationProperty -PSPath \"MACHINE/WEBROOT/APPHOST\" \
+                      -filter \"/system.webServer/security/requestFiltering/verbs/add\" \
+                      -Name \"verb\").Value")
+    its('stdout') { should eq "TRACE"}
+  end
 end

--- a/test/integration/config_property/config_property_spec.rb
+++ b/test/integration/config_property/config_property_spec.rb
@@ -20,6 +20,6 @@ control 'config_property' do
   describe powershell("(Get-WebConfigurationProperty -PSPath \"MACHINE/WEBROOT/APPHOST\" \
                       -filter \"/system.webServer/security/requestFiltering/verbs/add\" \
                       -Name \"verb\").Value") do
-    its('stdout') { should eq "TRACE"}
+    its('stdout') { should eq 'TRACE' }
   end
 end


### PR DESCRIPTION
### Description

The iis_config_property resource does not currently support values which require more than one property.  For example, the following command would not be supported currently since the value parameter has a hash which contains multiple keys:

`
    Add-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -Location "Default FTP Site" -Filter "/system.ftpServer/security/authorization" -Name "." -Value @{accessType='Allow';users='ftp_user';permissions='Read, Write'}
`

This PR would update the add action for the iis_config_property resource and allow the value property to use Hash values to support multiple properties.

The property custom resource property would be ignored if passing in a Hash to the value property.

Below are examples of how the custom resource would be used with multiple properties vs a single property:

    iis_config_property 'add_http_trace_method' do
      ps_path 'MACHINE/WEBROOT/APPHOST'
      filter 'system.webServer/security/requestFiltering/verbs'
      value(
        verb: 'TRACE',
        allowed: 'False'
      )
      action :add
    end

    iis_config_property 'configure_iis_test_new_index_default_document' do
      ps_path 'MACHINE/WEBROOT/APPHOST'
      filter '/system.webServer/defaultDocument/files'
      property 'value'
      value 'new-index.html'
      action :add
    end

Looking for feedback and suggestions on this implementation. Thanks!

### Issues Resolved

Issue #433 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>