### PR TITLE
Extend config_property to support setting multiple values on add

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Installs and configures Microsoft Internet Information Services (IIS) 7.0 and la
   - [iis_root](#iis_root) Allows for easy management of the IIS Root Machine settings
   - [iis_site](#iis_site) Allows for easy management of IIS virtual sites (ie vhosts).
   - [iis_config](#iis_config) Runs a config command on your IIS instance.
+  - [iis_config_property](#iis_config_property) Sets an IIS property idempotently via PowerShell.
   - [iis_pool](#iis_pool) Creates an application pool in IIS.
   - [iis_app](#iis_app) Creates an application in IIS.
   - [iis_vdir](#iis_vdir) Allows easy management of IIS virtual directories (i.e. vdirs).
@@ -304,6 +305,7 @@ Sets an IIS configuration property. Idempotent. Uses Powershell [Set-WebConfigur
 - `location` : Optional. The location of the configuration setting. Location tags are frequently used for configuration settings that must be set more precisely than per application or per virtual directory. For example, a setting for a particular file or directory could use a location tag. Location tags are also used if a particular section is locked. In such an instance, the configuration system would have to use a location tag in one of the parent configuration files.
 - `filter` : Specifies the IIS configuration section or an XPath query that returns a configuration element.
 - `value` : The value to set the property to. Either a string or an integer.
+- `extra_add_values` : Optional. If the `add` action requires additional values to be set at creation then supply them in this hash. This property is not idempotent. It is only used when the configuration is created.
 
 #### Example
 
@@ -330,6 +332,27 @@ iis_config_property 'Set X-Xss-Protection' do
   filter    "system.webServer/httpProtocol/customHeaders/add[@name='X-Xss-Protection']"
   property  'value'
   value     '1; mode=block'
+end
+```
+
+```ruby
+# Set environment variable ASPNETCORE_ENVIRONMENT to Test
+# Note we still need to maintain the value via a Set resource
+iis_config_property 'Add login/ASPNETCORE_ENVIRONMENT' do
+  ps_path           'MACHINE/WEBROOT/APPHOST'
+  location          'Default Web site'
+  filter            'system.webServer/aspNetCore/environmentVariables'
+  property          'name'
+  value             'ASPNETCORE_ENVIRONMENT'
+  extra_add_values  value: 'Test'
+  action            :add
+end
+iis_config_property 'Set login/ASPNETCORE_ENVIRONMENT' do
+  ps_path   'MACHINE/WEBROOT/APPHOST'
+  location  'Default Web site'
+  filter    "system.webServer/aspNetCore/environmentVariables/environmentVariable[@name='ASPNETCORE_ENVIRONMENT']"
+  property  'value'
+  value     'Test'
 end
 ```
 

--- a/resources/config_property.rb
+++ b/resources/config_property.rb
@@ -23,6 +23,7 @@ property :ps_path, String, required: true
 property :location, String
 property :filter, String, required: true
 property :value, [String, Integer], required: true
+property :extra_add_values, Hash
 
 action :set do
   location_param = "-location \"#{new_resource.location}\"" if
@@ -59,13 +60,21 @@ action :add do
   # powershell doesn't like { or } in xpath values (e.g. server variables)
   escaped_value = new_resource.value.gsub('{', '{{').gsub('}', '}}')
   escaped_filter = new_resource.filter.gsub('{', '{{').gsub('}', '}}')
+  extra_values = extra_add_values.map do |n, v|
+    property_value = if v.is_a?(Integer)
+                       v.to_s
+                     else
+                       "'#{v}'"
+                     end
+    "#{n} = #{property_value}"
+  end.join(';') if property_is_set?(:extra_add_values)
 
   powershell_script "Set #{new_resource.ps_path}#{new_resource.location}\
 /#{escaped_filter}/#{new_resource.property}" do
     code <<-EOH
     Add-WebConfigurationProperty -pspath "#{new_resource.ps_path}" \
     #{location_param} -filter "#{escaped_filter}" \
-    -name "." -value @{ #{new_resource.property} = '#{new_resource.value}'; } \
+    -name "." -value @{ #{new_resource.property} = '#{new_resource.value}'; #{extra_values} } \
     -ErrorAction Stop
     EOH
     only_if <<-EOH

--- a/resources/config_property.rb
+++ b/resources/config_property.rb
@@ -60,7 +60,7 @@ action :add do
   # powershell doesn't like { or } in xpath values (e.g. server variables)
   escaped_value = new_resource.value.gsub('{', '{{').gsub('}', '}}')
   escaped_filter = new_resource.filter.gsub('{', '{{').gsub('}', '}}')
-  extra_values = extra_add_values.map do |n, v|
+  extra_values = new_resource.extra_add_values.map do |n, v|
     property_value = if v.is_a?(Integer)
                        v.to_s
                      else

--- a/test/cookbooks/test/recipes/config_property.rb
+++ b/test/cookbooks/test/recipes/config_property.rb
@@ -61,3 +61,14 @@ iis_config_property 'Set X-Xss-Protection' do
   property  'value'
   value     '1; mode=block'
 end
+
+# Add environment variable + value
+iis_config_property 'Add login/ASPNETCORE_ENVIRONMENT' do
+  ps_path           'MACHINE/WEBROOT/APPHOST'
+  location          'Default Web site'
+  filter            'system.webServer/aspNetCore/environmentVariables'
+  property          'name'
+  value             'ASPNETCORE_ENVIRONMENT'
+  extra_add_values  value: 'Test'
+  action            :add
+end

--- a/test/integration/config_property/config_property_spec.rb
+++ b/test/integration/config_property/config_property_spec.rb
@@ -16,4 +16,11 @@ control 'config_property' do
                       -Name \"value\").value") do
     its('stdout') { should eq "1; mode=block\r\n" }
   end
+
+  describe powershell("(Get-WebConfigurationProperty -PSPath \"MACHINE/WEBROOT/APPHOST\" \
+                      -Location \"Default Web site\" \
+                      -filter \"system.webServer/aspNetCore/environmentVariables/environmentVariable[@name='ASPNETCORE_ENVIRONMENT']\" \
+                      -Name \"value\").value") do
+    its('stdout') { should eq "Test\r\n" }
+  end
 end


### PR DESCRIPTION
### Description

This fixes an edge case where adding a collection item requires that more than the key value is set. `aspNetCore/environmentVariables` is the use case that caused the change. The value must be set at the same time as the key.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
