### PR TITLE
Resource property default value that uses node attribute now uses lazy

### DIFF
--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -56,7 +56,7 @@ property :ping_response_time, String, default: '00:01:30'
 property :disallow_rotation_on_config_change, [true, false], default: false
 property :disallow_overlapping_rotation, [true, false], default: false
 property :recycle_schedule_clear, [true, false], default: false
-property :log_event_on_recycle, String, default: node['iis']['recycle']['log_events']
+property :log_event_on_recycle, String, default: lazy { node['iis']['recycle']['log_events'] }
 property :recycle_after_time, String
 property :periodic_restart_schedule, [Array, String], default: [], coerce: proc { |v| [*v].sort }
 property :private_memory, Integer, coerce: proc { |v| v.to_i }


### PR DESCRIPTION
Pool resource has a property, :log_event_on_recycle that's defualt value is set from a node attribute. That value is now evaluated lazily. 

### Description
This should be done using a lazy block to make sure it is initialised correctly 


### Issues Resolved
https://github.com/chef-cookbooks/iis/issues/455

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>